### PR TITLE
refactor: standardize filter stale time and retry count constants

### DIFF
--- a/src/shared/constants/app.ts
+++ b/src/shared/constants/app.ts
@@ -9,8 +9,9 @@ export const APP_OAUTH_PROVIDER = {
 export const AFTER_LOGIN_REDIRECT_PATH = PATH.DASHBOARD;
 
 /** config */
-export const FILTER_STALE_TIME = 0; // 5분
-export const RETRY_COUNT = 3;
+export const QUERY_RETRY_COUNT = 3;
+export const QUERY_DEFAULT_STALE_TIME = 1000 * 10; // 10초
+export const FILTER_STALE_TIME = QUERY_DEFAULT_STALE_TIME;
 export const API_TIMEOUT = 1000 * 5; // 5초
 export const ACCESS_TOKEN_EXPIRE = 60 * 60 * 1000; // 1시간
 export const REFRESH_TOKEN_EXPIRE = 7 * 24 * 60 * 60 * 1000; // 7일

--- a/src/shared/utils/react-query.ts
+++ b/src/shared/utils/react-query.ts
@@ -3,13 +3,17 @@ import {
   defaultShouldDehydrateQuery,
   isServer,
 } from "@tanstack/react-query";
-import { RETRY_COUNT } from "@/shared/constants/app";
+import {
+  QUERY_DEFAULT_STALE_TIME,
+  QUERY_RETRY_COUNT,
+} from "@/shared/constants/app";
 
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: {
       queries: {
-        retry: RETRY_COUNT,
+        retry: QUERY_RETRY_COUNT,
+        staleTime: QUERY_DEFAULT_STALE_TIME,
       },
       dehydrate: {
         shouldDehydrateQuery: (query) =>


### PR DESCRIPTION
- react-query의 stale time을 10초로 설정